### PR TITLE
Remsbasenamelkp

### DIFF
--- a/src/main/java/org/tts/repository/common/SBMLSpeciesRepository.java
+++ b/src/main/java/org/tts/repository/common/SBMLSpeciesRepository.java
@@ -23,7 +23,7 @@ import org.tts.model.common.SBMLSpecies;
 @Repository
 public interface SBMLSpeciesRepository extends Neo4jRepository<SBMLSpecies, Long> {
 	
-	public SBMLSpecies findBysBaseName(String sBaseName);
+	public List<SBMLSpecies> findBysBaseName(String sBaseName);
 
 	public SBMLSpecies findBysBaseId(String sBaseId);
 	

--- a/src/main/java/org/tts/service/SBMLFullModelServiceImpl.java
+++ b/src/main/java/org/tts/service/SBMLFullModelServiceImpl.java
@@ -757,7 +757,7 @@ public class SBMLFullModelServiceImpl implements SBMLService {
 					setSbaseProperties(qualSpecies, newQualSpecies);
 					//setCompartmentalizedSbaseProperties(qualSpecies, newQualSpecies, compartmentLookupMap);
 					setQualSpeciesProperties(qualSpecies, newQualSpecies);
-					newQualSpecies.setCorrespondingSpecies(this.sbmlSpeciesRepository.findBysBaseName(qualSpecies.getName()));
+					//newQualSpecies.setCorrespondingSpecies(this.sbmlSpeciesRepository.findBysBaseName(qualSpecies.getName()));
 					SBMLQualSpecies persistedNewQualSpecies = this.sbmlQualSpeciesRepository.save(newQualSpecies);
 					qualSpeciesMap.put(persistedNewQualSpecies.getsBaseId(), persistedNewQualSpecies);
 				}
@@ -801,7 +801,7 @@ public class SBMLFullModelServiceImpl implements SBMLService {
 				newSBMLQualSpeciesGroup.setsBaseName(qualSpeciesSbaseName);
 				newSBMLQualSpeciesGroup.setsBaseId(qualSpeciesSbaseName);
 				newSBMLQualSpeciesGroup.setsBaseMetaId("meta_" + qualSpeciesSbaseName);
-				newSBMLQualSpeciesGroup.setCorrespondingSpecies(this.sbmlSpeciesRepository.findBysBaseName(qualSpeciesSbaseName));
+				//newSBMLQualSpeciesGroup.setCorrespondingSpecies(this.sbmlSpeciesRepository.findBysBaseName(qualSpeciesSbaseName));
 				SBMLQualSpecies persistedNewQualSpecies = this.sbmlQualSpeciesRepository.save(newSBMLQualSpeciesGroup);
 				qualSpeciesMap.put(persistedNewQualSpecies.getsBaseId(), persistedNewQualSpecies);
 			}

--- a/src/main/java/org/tts/service/SimpleSBML/SBMLSpeciesService.java
+++ b/src/main/java/org/tts/service/SimpleSBML/SBMLSpeciesService.java
@@ -65,7 +65,7 @@ public class SBMLSpeciesService {
 	 * @param sBaseName The sBaseName attribute of the <a href="#{@link}">{@link SBMLSpecies}</a> to find
 	 * @return The SBMLSpecies with sBaseName fetched from the database
 	 */
-	public SBMLSpecies findBysBaseName(String sBaseName) {
+	public List<SBMLSpecies> findBysBaseName(String sBaseName) {
 		return this.sbmlSpeciesRepository.findBysBaseName(sBaseName);
 		
 	}
@@ -105,16 +105,17 @@ public class SBMLSpeciesService {
 	 */
 	public Map<String, SBMLSpecies> findAllBySymbol(String symbol, boolean searchBQConnections) {
 		Map<String, SBMLSpecies> allSpecies = new HashMap<>();
-		SBMLSpecies geneSpecies = this.findBysBaseName(symbol);
-		if (geneSpecies != null) {
-			allSpecies.put(geneSpecies.getEntityUUID(), geneSpecies);
-		}
-		if(searchBQConnections) {
-			Iterable<SBMLSpecies> bqSpecies = this.findByBQConnectionTo(symbol, sbml4jConfig.getExternalResourcesProperties().getBiologicalQualifierProperties().getDefaultDatabase());
-			Iterator<SBMLSpecies> bqSpeciesIterator = bqSpecies.iterator();
-			while(bqSpeciesIterator.hasNext()) {
-				SBMLSpecies current = bqSpeciesIterator.next();
-				allSpecies.putIfAbsent(current.getEntityUUID(), current);
+		for (SBMLSpecies geneSpecies : this.findBysBaseName(symbol)) {
+			if (geneSpecies != null) {
+				allSpecies.put(geneSpecies.getEntityUUID(), geneSpecies);
+			}
+			if(searchBQConnections) {
+				Iterable<SBMLSpecies> bqSpecies = this.findByBQConnectionTo(symbol, sbml4jConfig.getExternalResourcesProperties().getBiologicalQualifierProperties().getDefaultDatabase());
+				Iterator<SBMLSpecies> bqSpeciesIterator = bqSpecies.iterator();
+				while(bqSpeciesIterator.hasNext()) {
+					SBMLSpecies current = bqSpeciesIterator.next();
+					allSpecies.putIfAbsent(current.getEntityUUID(), current);
+				}
 			}
 		}
 		return allSpecies;


### PR DESCRIPTION
SBaseName is not unique on SBMLSpecies anymore, therefore findBysBaseName can return multiple SBMLSpecies.
Methods using the function therefore need to deal with collections now.