### PR TITLE
Create Long from String if type is integer (no cast to Integer)

### DIFF
--- a/src/main/java/org/sbml4j/service/base/GraphBaseEntityService.java
+++ b/src/main/java/org/sbml4j/service/base/GraphBaseEntityService.java
@@ -79,7 +79,8 @@ public class GraphBaseEntityService {
 				if("integer".equals(annotationType)) {
 					// The neo4j database cannot handle the Java Type Integer.
 					// Those values need to be converted to Long
-					entity.addAnnotation(annotationName, Long.valueOf(((Integer) annotationValue).intValue()));
+					entity.addAnnotation(annotationName, Long.valueOf((String) annotationValue));
+					
 				} else {
 					entity.addAnnotation(annotationName, annotationValue);
 				}


### PR DESCRIPTION
The cast through Integer did not work.
Instead directly create a Long from the value of the String, that is cast from the object in annotationValue.