### PR TITLE
Graphml empty annotation value

### DIFF
--- a/src/main/java/org/sbml4j/service/GraphMLServiceImpl.java
+++ b/src/main/java/org/sbml4j/service/GraphMLServiceImpl.java
@@ -569,7 +569,7 @@ public class GraphMLServiceImpl implements GraphMLService {
 						NodeList nodeChildren = currentChild.getChildNodes();
 						for (int k = 0; k != nodeChildren.getLength(); k++) {
 							Node dataNode = nodeChildren.item(k);
-							if (dataNode.getNodeName().equals("data")) {
+							if (dataNode.getNodeName().equals("data") && dataNode.getFirstChild() != null) {
 								// this is an annotation
 								String speciesAnnotationName = nodeAnnotationMap.get(dataNode.getAttributes().getNamedItem("key").getNodeValue()).getLeft(); // name
 								

--- a/src/main/java/org/sbml4j/service/GraphMLServiceImpl.java
+++ b/src/main/java/org/sbml4j/service/GraphMLServiceImpl.java
@@ -672,13 +672,13 @@ public class GraphMLServiceImpl implements GraphMLService {
 						NodeList nodeChildren = currentChild.getChildNodes();
 						for (int k = 0; k != nodeChildren.getLength(); k++) {
 							Node dataNode = nodeChildren.item(k);
-							if (dataNode.getNodeName().equals("data")) {
+							if (dataNode.getNodeName().equals("data") && dataNode.getFirstChild() != null) {
 								// this is an annotation
 								String edgeAnnotationName = edgeAnnotationMap.get(dataNode.getAttributes().getNamedItem("key").getNodeValue()).getLeft(); // name
 								
 								String edgeAnnotationType = edgeAnnotationMap.get(dataNode.getAttributes().getNamedItem("key").getNodeValue()).getRight();
 								String edgeAnnotationValue = dataNode.getFirstChild().getNodeValue(); // 8644
-								
+																
 								if(isSetGraphMLSboTermKey && edgeAnnotationName.equals(this.configService.getGraphMLSboTermKey())) {
 									hasSBOTerm = true;
 									sboTerm = edgeAnnotationValue;


### PR DESCRIPTION
If a data annotation element exists but has no value, the dataNode.getFirstChild() call will result in NULL, and hence cannot be used to extract the annotationValue. No annotation shall be created on the node or relationship for that key.